### PR TITLE
Organization defined in the env variable ORG is grouped separately 

### DIFF
--- a/cmd/goimports/goimports.go
+++ b/cmd/goimports/goimports.go
@@ -51,6 +51,7 @@ var (
 			GO111MODULE: os.Getenv("GO111MODULE"),
 			GOPROXY:     os.Getenv("GOPROXY"),
 			GOSUMDB:     os.Getenv("GOSUMDB"),
+			ORG:         os.Getenv("ORG"),
 		},
 	}
 	exitCode = 0

--- a/internal/imports/fix.go
+++ b/internal/imports/fix.go
@@ -36,9 +36,12 @@ var importToGroup = []func(env *ProcessEnv, importPath string) (num int, ok bool
 		if env.LocalPrefix == "" {
 			return
 		}
-		for _, p := range strings.Split(env.LocalPrefix, ",") {
+		for i, p := range strings.Split(env.LocalPrefix, ",") {
 			if strings.HasPrefix(importPath, p) || strings.TrimSuffix(p, "/") == importPath {
-				return 3, true
+				return 3 + i, true
+			}
+			if env.ORG != "" && strings.HasPrefix(importPath, env.ORG) {
+				return 4 + i, true
 			}
 		}
 		return
@@ -51,7 +54,7 @@ var importToGroup = []func(env *ProcessEnv, importPath string) (num int, ok bool
 	},
 	func(_ *ProcessEnv, importPath string) (num int, ok bool) {
 		if strings.Contains(importPath, ".") {
-			return 1, true
+			return 999, true // ¯\_(ツ)_/¯
 		}
 		return
 	},
@@ -751,8 +754,8 @@ type ProcessEnv struct {
 
 	// If non-empty, these will be used instead of the
 	// process-wide values.
-	GOPATH, GOROOT, GO111MODULE, GOPROXY, GOFLAGS, GOSUMDB string
-	WorkingDir                                             string
+	GOPATH, GOROOT, GO111MODULE, GOPROXY, GOFLAGS, GOSUMDB, ORG string
+	WorkingDir                                                  string
 
 	// If Logf is non-nil, debug logging is enabled through this function.
 	Logf func(format string, args ...interface{})

--- a/internal/imports/sortimports.go
+++ b/internal/imports/sortimports.go
@@ -37,13 +37,6 @@ func sortImports(env *ProcessEnv, fset *token.FileSet, f *ast.File) {
 		// Identify and sort runs of specs on successive lines.
 		i := 0
 		specs := d.Specs[:0]
-		for j, s := range d.Specs {
-			if j > i && fset.Position(s.Pos()).Line > 1+fset.Position(d.Specs[j-1].End()).Line {
-				// j begins a new run.  End this one.
-				specs = append(specs, sortSpecs(env, fset, f, d.Specs[i:j])...)
-				i = j
-			}
-		}
 		specs = append(specs, sortSpecs(env, fset, f, d.Specs[i:])...)
 		d.Specs = specs
 


### PR DESCRIPTION
Organization defined in the env variable ORG is grouped separately.
Ignore user defined empty lines between imports.
If few packages are provided in `local`, the each group will be intended with new line.